### PR TITLE
Added delegate to get callback for scrollview did end

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -154,6 +154,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)calendarCurrentPageDidChange:(FSCalendar *)calendar;
 
 /**
+ Tells the delegate the calendar scrollView did finish scrolling.
+ */
+- (void)calendarScrollViewDidEndScroll:(UIScrollView *)scrollView;
+
+/**
  These functions are deprecated
  */
 - (void)calendarCurrentScopeWillChange:(FSCalendar *)calendar animated:(BOOL)animated FSCalendarDeprecated(-calendar:boundingRectWillChange:animated:);

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -635,6 +635,11 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     }
 }
 
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    [self.delegateProxy calendarScrollViewDidEndScroll:scrollView];
+}
+
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
     if (!_pagingEnabled || !_scrollEnabled) {


### PR DESCRIPTION
**Implementation**

Added a delegate which gives us callback when the calendar scroll view did ended. We needed this for the duration discount project  where we want to show the pop up after the scrollview did end