### PR TITLE
Expose timezone

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -257,6 +257,11 @@ IB_DESIGNABLE
 @interface FSCalendar : UIView
 
 /**
+  * The timezone of the calendar. `defaultTimeZone` by default.
+  */
+ @property (strong, nonatomic) NSTimeZone *timeZone;
+
+/**
  * The object that acts as the delegate of the calendar.
  */
 @property (weak, nonatomic) IBOutlet id<FSCalendarDelegate> delegate;

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -50,7 +50,6 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 
 @property (strong, nonatomic) NSCalendar *gregorian;
 @property (strong, nonatomic) NSDateFormatter *formatter;
-@property (strong, nonatomic) NSTimeZone *timeZone;
 
 @property (weak  , nonatomic) UIView                     *contentView;
 @property (weak  , nonatomic) UIView                     *daysContainer;
@@ -279,6 +278,12 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     
     return [super setValue:value forUndefinedKey:key];
     
+}
+
+- (void)setTimeZone:(NSTimeZone *)tz
+{
+    _timeZone = tz;
+    [self invalidateDateTools];
 }
 
 - (void)layoutSubviews
@@ -708,6 +713,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     } else {
         FSCalendarAssertDateInBounds(today,self.gregorian,self.minimumDate,self.maximumDate);
         _today = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:today options:0];
+        [self updateToday];
     }
     if (self.hasValidateVisibleLayout) {
         [self.visibleCells makeObjectsPerformSelector:@selector(setDateIsToday:) withObject:nil];
@@ -1278,6 +1284,18 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     _formatter.calendar = _gregorian;
     _formatter.timeZone = _timeZone;
     _formatter.locale = _locale;
+
+    [self updateToday];
+}
+
+- (void)updateToday
+{
+    NSDateComponents *dateComponents = [self.gregorian components:(NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay) fromDate:[NSDate date]];
+    dateComponents.hour = 0;
+    dateComponents.minute = 0;
+    dateComponents.second = 0;
+    dateComponents.timeZone = self.timeZone;
+    _today = [self.gregorian dateFromComponents:dateComponents];
 }
 
 - (void)invalidateLayout


### PR DESCRIPTION
We currently have some bugs and funky behavior because the Calendar always initializes with the device timezone. We don't want that, we want the calendar to use vehicle's timezone. 

This PR exposes the timezone and resets the calendar when we set it from outside.